### PR TITLE
Add View Definitions to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 `crossfhir` is a CLI tool to interact with AWS HealthLake FHIR datastore and easily migrate it to PostgreSQL.
 
-## Features overview
+## Roadmap
 
 ### General features
 
@@ -36,6 +36,12 @@ For more information, check the FAQ section.
 - ✅ Migrating .ndjson files from FHIR v4 resources into specific tables.
 - Indexing desired elements of resources and separating them from the jsonb column.
 - Handling resource versioning and updates.
+
+### View Definitions
+
+- Generating SQL queries using FHIR View Definitions
+- Support running SQL .ndjson files in memory using DuckDB
+
 
 ## Installation
 
@@ -94,8 +100,6 @@ export DB_DATABASE=postgres
 If you want to work directly with the source code, you need to have Go installed on your machine.
 
 ## Usage
-
-There is a binary in this repository that you can use if you don't have Go installed.
 
 ```
 $ crossfhir


### PR DESCRIPTION
Due to the problem of representing FHIR resources in SQL databases, a new structure - View Definitions - is being developed.
More information is available here: https://sql-on-fhir.org/ig/latest/
This tool offers a different approach from PostgreSQL data loading. We can query data directly from JSON by creating a tool that will translate view definitions into SQL and query files (for instance, with in-memory [DuckDB](https://duckdb.org/)).

I would separate the commands like this:

```
# commands for interacting with AWS
crossfhir aws export
crossfhir aws pull 

# Interaction with Postgres
crossfhir pg load

# Generating, running queries on .ndjson data set 
crossfhir sql generate --path some.vd.json --data somepath
crossfhir sql run --path some.vd.json --data somepath
```